### PR TITLE
Install LLVM into its own directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ linuxbrew_path.txt
 *.orig
 *.rej
 .vscode
+installed_*/

--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -50,7 +50,7 @@ else
 fi
 
 echo "YB_LINUXBREW_DIR=${YB_LINUXBREW_DIR:-undefined}"
-if [[ $OSTYPE == linux* && -n $YB_LINUXBREW_DIR ]]; then
+if [[ $OSTYPE == linux* && -n ${YB_LINUXBREW_DIR:-} ]]; then
   if [[ ! -d $YB_LINUXBREW_DIR ]]; then
     fatal "Directory specified by YB_LINUXBREW_DIR ('$YB_LINUXBREW_DIR') does not exist"
   fi


### PR DESCRIPTION
If the clang toolchain is installed into `installed/common`, we get a lot of errors like the following during YugabyteDB build:
```
CMake Warning at CMakeLists.txt:363 (_add_executable):
 Cannot generate a safe runtime search path for target ql-transaction-test
 because files in some directories may conflict with libraries in implicit
 directories:
   runtime library [libz.so.1] in /opt/yb-build/thirdparty/yugabyte-db-thirdparty-v20191114222832-7d7f4e9097-centos/installed/common/lib may be hidden by files in:
     /opt/yb-build/brew/linuxbrew-20191021T231003/lib
 Some of these libraries may not be found correctly.
Call Stack (most recent call first):
 CMakeLists.txt:1213 (add_executable)
 src/yb/client/CMakeLists.txt:117 (ADD_YB_TEST)
```

Also we have an old comment saying:
```
        # Create a link from Clang to thirdparty/clang-toolchain. This path is used	
        # for all Clang invocations. The link can't point to the Clang installed in	
        # the prefix directory, since this confuses CMake into believing the	
        # thirdparty prefix directory is the system-wide prefix, and it omits the	
        # thirdparty prefix directory from the rpath of built binaries.
```
This is why for a long time we've been running clang from its build directory, not from its install directory, during YugabyteDB builds, and this does not work when pre-building third-party dependencies and then installing them from a tar.gz.