### PR TITLE
#3044: Fixed --download-thirdparty mode (#yugabyte-db/issues/3044)

### DIFF
--- a/linuxbrew_url.txt
+++ b/linuxbrew_url.txt
@@ -1,1 +1,1 @@
-https://github.com/yugabyte/brew-build/releases/download/20181203T161736/linuxbrew-20181203T161736.tar.gz
+https://github.com/yugabyte/brew-build/releases/download/20181203T161736/linuxbrew-20181203T161736v2.tar.gz


### PR DESCRIPTION
Updated linuxbrew_url with repackaged version to fix `--download-thirdparty` mode which was broken due to rollback done by https://github.com/yugabyte/yugabyte-db/issues/3044.