### PR TITLE
Fix how icu4c dynamic libraries refer to themselves and each other on macOS

### DIFF
--- a/yb_build_thirdparty_main.py
+++ b/yb_build_thirdparty_main.py
@@ -733,6 +733,7 @@ class Builder:
             BUILD_GROUP_COMMON if build_type == BUILD_TYPE_COMMON
                                else BUILD_GROUP_INSTRUMENTED
         )
+
         for dep in self.selected_dependencies:
             if dep.build_group == build_group and dep.should_build(self):
                 self.build_dependency(dep)


### PR DESCRIPTION
Add a post-processing step to the icu4c build on macOS to make sure every library will refer to itself using @rpath and other libraries @loader_path.
```
$ otool -L ./libicui18n.dylib
./libicui18n.dylib:
	@rpath/libicui18n.67.dylib (compatibility version 67.0.0, current version 67.1.0)
	@loader_path/libicuuc.67.dylib (compatibility version 67.0.0, current version 67.1.0)
	@loader_path/libicudata.67.dylib (compatibility version 67.0.0, current version 67.1.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 400.9.4)
	/usr/lib/libc++abi.dylib (compatibility version 1.0.0, current version 400.17.0)
```