### PR TITLE
Build curl without extra libraries

### DIFF
--- a/build_definitions/curl.py
+++ b/build_definitions/curl.py
@@ -33,5 +33,11 @@ class CurlDependency(Dependency):
 
         extra_args.append('--with-ssl=%s' % builder.get_openssl_dir())
         extra_args.append('--with-zlib=%s' % builder.get_openssl_dir())
+        extra_args += [
+            '--without-brotli',
+            '--without-libidn2',
+            '--without-librtmp',
+            '--without-nghttp2'
+        ]
 
         builder.build_with_configure(builder.log_prefix(self), extra_args)


### PR DESCRIPTION
This is to address yugabyte/yugabyte-db#4743.
We are trying to avoid references to libraries like these, even if they are installed on the build host.

    /usr/local/opt/brotli/lib/libbrotlidec.1.dylib (compatibility version 1.0.0, current version 1.0.7)
    /usr/local/opt/libidn2/lib/libidn2.0.dylib (compatibility version 4.0.0, current version 4.7.0)
    /usr/local/opt/nghttp2/lib/libnghttp2.14.dylib (compatibility version 35.0.0, current version 35.0.0)
    /usr/local/opt/rtmpdump/lib/librtmp.1.dylib (compatibility version 0.0.0, current version 0.0.0)

Here is the full list of curl's configure options, just in case:

https://gist.githubusercontent.com/mbautin/d84f58bbf7875cbeb70cc3eb35cac7d9/raw