### PR TITLE
Fix build job redundancy in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,6 @@ jobs:
       docker_image:
         type: string
 
-    parallelism: 2
-
     # Need docker run with SYS_PTRACE for address sanitizer to work
     machine:
       enabled: true


### PR DESCRIPTION
yugabyte/yugabyte-db#4965

The parallelism statement is running two instances of a job instead of
allowing two jobs to run concurrently. This resulted in redundant
releases.