### PR TITLE
fossa: generate fossa-deps.json config

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,13 @@
+
+version: 3
+
+project:
+  id: yugabyte-db-thirdparty
+
+revision:
+  branch: master
+
+# Look only at fossa-deps.yml
+paths:
+  only:
+    - None

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -265,7 +265,7 @@ class Builder(BuilderInterface):
         for build_type in build_types:
             self.build_one_build_type(build_type)
 
-        fossa_config_deps = { "remote-dependencies": self.fossa_deps }
+        fossa_config_deps = {"remote-dependencies": self.fossa_deps}
         with open(os.path.join(YB_THIRDPARTY_DIR, 'fossa-deps.json'), 'w') as output_file:
             json.dump(fossa_config_deps, output_file, indent=2)
 


### PR DESCRIPTION
This replaces the fossa-modules.yml file that was pulled into fossa
analysis in the yugabyte-db repo. This assumes analyzing this
yugabyte-db-thirdparty repo directly.

Test:
  ./build_thirdparty.sh  --download-extract-only
  fossa analyze -o

To-Do: Add to release workflow