### PR TITLE
Support for Clang 12 build for Linuxbrew (to replace GCC 5.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,42 +35,42 @@ jobs:
           # CentOS 7
           # ---------------------------------------------------------------------------------------
           - name: centos7-x86_64-linuxbrew-gcc5
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=linuxbrew
               --expected-major-compiler-version=5
 
           - name: centos7-x86_64-gcc8
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
                 --devtoolset=8
                 --expected-major-compiler-version=8
 
           - name: centos7-x86_64-gcc9
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --devtoolset=9
               --expected-major-compiler-version=9
 
           - name: centos7-x86_64-clang7
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=llvm7
               --expected-major-compiler-version=7
 
           - name: centos7-x86_64-clang11
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=llvm11
               --expected-major-compiler-version=11
 
           - name: centos7-x86_64-clang12
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos7:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=llvm12
@@ -81,7 +81,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: centos8-x86_64-gcc8
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -89,7 +89,7 @@ jobs:
               --expected-major-compiler-version=8
 
           - name: centos8-x86_64-gcc9
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_centos8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --devtoolset=9
@@ -100,7 +100,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: ubuntu1804-x86_64-gcc7
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu1804:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -109,7 +109,7 @@ jobs:
               --expected-major-compiler-version=7
 
           - name: ubuntu1804-x86_64-gcc8
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu1804:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -118,7 +118,7 @@ jobs:
               --expected-major-compiler-version=8
 
           - name: ubuntu1804-x86_64-clang10
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu1804:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --single-compiler-type=clang
@@ -127,7 +127,7 @@ jobs:
               --expected-major-compiler-version=10
 
           - name: ubuntu1804-x86_64-clang11
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu1804:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --single-compiler-type=clang
@@ -140,7 +140,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: ubuntu2004-x86_64-gcc9
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu2004:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -149,7 +149,7 @@ jobs:
               --expected-major-compiler-version=9
 
           - name: ubuntu2004-x86_64-clang11
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_ubuntu2004:v2021-08-27T03_10_20
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -162,7 +162,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: almalinux8-x86_64-gcc8
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_almalinux8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --compiler-prefix=/usr
@@ -170,7 +170,7 @@ jobs:
               --expected-major-compiler-version=8
 
           - name: almalinux8-x86_64-gcc9
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_almalinux8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --single-compiler-type=gcc
@@ -178,17 +178,24 @@ jobs:
               --expected-major-compiler-version=9
 
           - name: almalinux8-x86_64-clang11
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_almalinux8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=llvm11
               --expected-major-compiler-version=11
 
           - name: almalinux8-x86_64-clang12
-            os: ubuntu-20.04
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_almalinux8:v2021-08-27T03_10_19
             build_thirdparty_args: >-
               --toolchain=llvm12
+              --expected-major-compiler-version=12
+
+          - name: almalinux8-x86_64-clang12-linuxbrew
+            os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
+            docker_image: yugabyteci/yb_build_infra_almalinux8:v2021-08-27T03_10_19
+            build_thirdparty_args: >-
+              --toolchain=llvm12_linuxbrew
               --expected-major-compiler-version=12
 
           # ---------------------------------------------------------------------------------------

--- a/python/build_definitions/boost.py
+++ b/python/build_definitions/boost.py
@@ -70,6 +70,7 @@ class BoostDependency(Dependency):
                         not lstripped.startswith('project : default-build <toolset>gcc ;')):
                     out.write(line)
             cxx_flags = builder.compiler_flags + builder.cxx_flags
+            log("C++ flags to use when building Boost: %s", cxx_flags)
             compiler_type = builder.compiler_choice.compiler_type
             # To make sure Boost's b2 does not select one of its default "toolsets" and ignores all
             # of our compiler flags, we add a "-yb" suffix to the compiler "version" that we give

--- a/python/build_definitions/boost.py
+++ b/python/build_definitions/boost.py
@@ -81,11 +81,12 @@ class BoostDependency(Dependency):
             out.write(PROJECT_CONFIG.format(
                     compiler_type,
                     compiler_version,
-                    builder.compiler_choice.get_cxx_compiler(),
+                    builder.compiler_choice.get_cxx_compiler_or_wrapper(),
                     ' '.join(['<compileflags>' + flag for flag in cxx_flags]),
                     ' '.join(['<linkflags>' + flag for flag in cxx_flags + builder.ld_flags]),
                     ' '.join(['--with-{}'.format(lib) for lib in libs])))
-        build_cmd = ['./b2', 'install', 'cxxstd=14', 'toolset=%s' % boost_toolset]
+        # -q means stop at first error
+        build_cmd = ['./b2', 'install', 'cxxstd=14', 'toolset=%s' % boost_toolset, '-q']
         if is_macos_arm64_build():
             build_cmd.append('instruction-set=arm64')
         log_output(log_prefix, build_cmd)

--- a/python/build_definitions/snappy.py
+++ b/python/build_definitions/snappy.py
@@ -53,7 +53,7 @@ class SnappyDependency(Dependency):
         builder.build_with_configure(
             log_prefix=log_prefix,
             extra_args=['--with-pic'],
-            post_configure_action=self._disable_lzo2_library_in_test
+            post_configure_action=self._disable_lzo2_library_in_test,
         )
         # Copy over all the headers into a generic include/ directory.
         mkdir_if_missing('include')

--- a/python/build_definitions/snappy.py
+++ b/python/build_definitions/snappy.py
@@ -48,7 +48,6 @@ class SnappyDependency(Dependency):
         with open('config.h', 'w') as output_file:
             output_file.write('\n'.join(lines) + '\n')
 
-
     def build(self, builder: BuilderInterface) -> None:
         log_prefix = builder.log_prefix(self)
         builder.build_with_configure(

--- a/python/yugabyte_db_thirdparty/builder_interface.py
+++ b/python/yugabyte_db_thirdparty/builder_interface.py
@@ -10,7 +10,7 @@
 # or implied. See the License for the specific language governing permissions and limitations
 # under the License.
 
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Callable, TYPE_CHECKING
 
 from yugabyte_db_thirdparty.file_system_layout import FileSystemLayout
 
@@ -48,7 +48,8 @@ class BuilderInterface:
             install: List[str] = ['install'],
             run_autogen: bool = False,
             autoconf: bool = False,
-            src_subdir_name: Optional[str] = None) -> None:
+            src_subdir_name: Optional[str] = None,
+            post_configure_action: Optional[Callable] = None) -> None:
         raise NotImplementedError()
 
     def build_with_cmake(

--- a/python/yugabyte_db_thirdparty/clang_util.py
+++ b/python/yugabyte_db_thirdparty/clang_util.py
@@ -47,7 +47,7 @@ def get_clang_library_dir(clang_executable_path: str) -> str:
     raise ValueError(
         f"Could not find a 'lib/linux' subdirectory in any of the library directories "
         f"returned by 'clang -print-search-dirs' (clang path: {clang_executable_path}):\n"
-        f"{search_dirs_output}\n.Considered candidate directories:{candidate_dirs}")
+        f"{library_dirs}\n.Considered candidate directories:{candidate_dirs}")
 
 
 def get_clang_include_dir(clang_executable_path: str) -> str:
@@ -57,4 +57,4 @@ def get_clang_include_dir(clang_executable_path: str) -> str:
         if os.path.isdir(include_dir):
             return include_dir
     raise ValueError(
-        f"Could not find a directory from {library_dirs} that has an 'include' subdirectory")
+        f"Could not find a directory from {library_dirs} that has an 'include' subdirectory.")

--- a/python/yugabyte_db_thirdparty/compiler_choice.py
+++ b/python/yugabyte_db_thirdparty/compiler_choice.py
@@ -148,6 +148,7 @@ class CompilerChoice:
     def _do_find_gcc(self, c_compiler: str, cxx_compiler: str) -> Tuple[str, str]:
         if using_linuxbrew():
             gcc_dir = get_linuxbrew_dir()
+            assert gcc_dir is not None
         elif self.compiler_prefix:
             gcc_dir = self.compiler_prefix
         else:

--- a/python/yugabyte_db_thirdparty/compiler_wrapper.py
+++ b/python/yugabyte_db_thirdparty/compiler_wrapper.py
@@ -88,7 +88,6 @@ class CompilerWrapper:
                 real_included_files = set(os.path.realpath(p) for p in included_files)
                 sys.stderr.write("Included files:\n%s" % "\n".join(sorted(real_included_files)))
 
-
         subprocess.check_call(cmd_args)
         cmd_str = '( cd %s; %s )' % (shlex.quote(os.getcwd()), shlex_join(cmd_args))
         sys.stderr.write(cmd_str)

--- a/python/yugabyte_db_thirdparty/compiler_wrapper.py
+++ b/python/yugabyte_db_thirdparty/compiler_wrapper.py
@@ -31,6 +31,10 @@ class CompilerWrapper:
         use_ccache = os.getenv('YB_THIRDPARTY_USE_CCACHE') == '1'
 
         compiler_args = sys.argv[1:]
+        compiler_args = [
+            arg for arg in compiler_args
+            if arg != '-I"/usr/include"'
+        ]
 
         compiler_path_and_args = [real_compiler_path] + compiler_args
 
@@ -83,6 +87,7 @@ class CompilerWrapper:
                             included_files.add(line[:quote_pos])
                 real_included_files = set(os.path.realpath(p) for p in included_files)
                 sys.stderr.write("Included files:\n%s" % "\n".join(sorted(real_included_files)))
+
 
         subprocess.check_call(cmd_args)
         cmd_str = '( cd %s; %s )' % (shlex.quote(os.getcwd()), shlex_join(cmd_args))

--- a/python/yugabyte_db_thirdparty/compiler_wrapper.py
+++ b/python/yugabyte_db_thirdparty/compiler_wrapper.py
@@ -15,47 +15,68 @@ from yugabyte_db_thirdparty.util import shlex_join
 class CompilerWrapper:
     is_cxx: bool
     args: List[str]
+    real_compiler_path: str
+    language: str
+    compiler_args: List[str]
+    disallowed_include_dirs: List[str]
 
     def __init__(self, is_cxx: bool) -> None:
         self.is_cxx = is_cxx
         self.args = sys.argv
+        if self.is_cxx:
+            self.real_compiler_path = os.environ['YB_THIRDPARTY_REAL_CXX_COMPILER']
+            self.language = 'C++'
+        else:
+            self.real_compiler_path = os.environ['YB_THIRDPARTY_REAL_C_COMPILER']
+            self.language = 'C'
+
+        disallowed_include_dirs_colon_separated = os.getenv('YB_DISALLOWED_INCLUDE_DIRS')
+        self.disallowed_include_dirs = []
+        if disallowed_include_dirs_colon_separated:
+            self.disallowed_include_dirs = disallowed_include_dirs_colon_separated.split(':')
+        self.compiler_args = self._filter_args(sys.argv[1:])
+
+    def _is_permitted_arg(self, arg: str) -> bool:
+        if not arg.startswith('-I'):
+            return True
+        include_path = arg[1:]
+        if include_path.startswith('"') and include_path.endswith('"') and len(include_path) >= 2:
+            include_path = include_path[1:-1]
+        return include_path not in self.disallowed_include_dirs
+
+    def _filter_args(self, compiler_args: List[str]) -> List[str]:
+        return [arg for arg in compiler_args if self._is_permitted_arg(arg)]
+
+    def _get_compiler_path_and_args(self) -> List[str]:
+        return [self.real_compiler_path] + self.compiler_args
+
+    def _get_compiler_command_str(self) -> str:
+        return shlex_join(self._get_compiler_path_and_args())
 
     def run(self) -> None:
-        if self.is_cxx:
-            real_compiler_path = os.environ['YB_THIRDPARTY_REAL_CXX_COMPILER']
-            language = 'C++'
-        else:
-            real_compiler_path = os.environ['YB_THIRDPARTY_REAL_C_COMPILER']
-            language = 'C'
 
         use_ccache = os.getenv('YB_THIRDPARTY_USE_CCACHE') == '1'
 
-        compiler_args = sys.argv[1:]
-        compiler_args = [
-            arg for arg in compiler_args
-            if arg != '-I"/usr/include"'
-        ]
-
-        compiler_path_and_args = [real_compiler_path] + compiler_args
+        compiler_path_and_args = self._get_compiler_path_and_args()
 
         if use_ccache:
-            os.environ['CCACHE_COMPILER'] = real_compiler_path
-            cmd_args = ['ccache', 'compiler'] + compiler_args
+            os.environ['CCACHE_COMPILER'] = self.real_compiler_path
+            cmd_args = ['ccache', 'compiler'] + self.compiler_args
         else:
-            cmd_args = compiler_path_and_args
+            cmd_args = self._get_compiler_path_and_args()
 
         output_files = []
-        for i in range(len(compiler_args) - 1):
-            if compiler_args[i] == '-o':
-                output_files.append(compiler_args[i + 1])
+        for i in range(len(self.compiler_args) - 1):
+            if self.compiler_args[i] == '-o':
+                output_files.append(self.compiler_args[i + 1])
 
         if len(output_files) == 1 and output_files[0].endswith('.o'):
             pp_output_path = None
             # Perform preprocessing only to ensure we are using the correct include directories.
-            pp_args = [real_compiler_path]
+            pp_args = [self.real_compiler_path]
             out_file_arg_follows = False
             assembly_input = False
-            for arg in compiler_args:
+            for arg in self.compiler_args:
                 if arg.endswith('.s'):
                     assembly_input = True
                 if out_file_arg_follows:
@@ -86,7 +107,15 @@ class CompilerWrapper:
                                 continue
                             included_files.add(line[:quote_pos])
                 real_included_files = set(os.path.realpath(p) for p in included_files)
-                sys.stderr.write("Included files:\n%s" % "\n".join(sorted(real_included_files)))
+
+                for disallowed_dir in self.disallowed_include_dirs:
+                    for included_file in real_included_files:
+                        if included_file.startswith(disallowed_dir + '/'):
+                            raise ValueError(
+                                "File from a disallowed directory included: %s. "
+                                "Compiler invocation: %s" % (
+                                    included_file,
+                                    self._get_compiler_command_str()))
 
         subprocess.check_call(cmd_args)
         cmd_str = '( cd %s; %s )' % (shlex.quote(os.getcwd()), shlex_join(cmd_args))

--- a/python/yugabyte_db_thirdparty/linuxbrew.py
+++ b/python/yugabyte_db_thirdparty/linuxbrew.py
@@ -1,0 +1,84 @@
+# Copyright (c) Yugabyte, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations
+# under the License.
+#
+
+# We use Linuxbrew as a portable set of libraries, including glibc and ncurses, that we can build
+# our code with so it would run on most Linux systems. The Linuxbrew archive we use includes
+# GCC 5.5.0, but we also support building the code for Linuxbrew with Clang 12 (we use the Clang
+# package built specifically for the host OS, e.g. RHEL 7 or RHEL 8, not for Linuxbrew).
+# Building with a modern version of Clang for Linuxbrew is the preferred build method
+# for 12/21/2021.
+
+import os
+
+from sys_detection import is_macos, is_linux
+
+from typing import Optional
+
+from yugabyte_db_thirdparty.custom_logging import log
+from yugabyte_db_thirdparty.util import add_path_entry
+
+
+g_linuxbrew_dir: Optional[str] = None
+g_detect_linuxbrew_called: bool = False
+
+
+def get_linuxbrew_dir() -> Optional[str]:
+    global g_detect_linuxbrew_called
+    if not g_detect_linuxbrew_called:
+        _detect_linuxbrew()
+        g_get_linuxbrew_dir_called = True
+    return g_linuxbrew_dir
+
+
+def _detect_linuxbrew() -> None:
+    global g_linuxbrew_dir
+    if not is_linux():
+        log("Not using Linuxbrew -- this is not Linux")
+        return
+
+    linuxbrew_dir_from_env = os.getenv('YB_LINUXBREW_DIR')
+    if linuxbrew_dir_from_env:
+        g_linuxbrew_dir = linuxbrew_dir_from_env
+        log("Setting Linuxbrew directory based on YB_LINUXBREW_DIR env var: %s",
+            linuxbrew_dir_from_env)
+        return
+
+    # if self.compiler_prefix:
+    #     compiler_prefix_basename = os.path.basename(self.compiler_prefix)
+    #     if compiler_prefix_basename.startswith('linuxbrew'):
+    #         g_linuxbrew_dir = self.compiler_prefix
+    #         log("Setting Linuxbrew directory based on compiler prefix %s",
+    #             self.compiler_prefix)
+
+    if g_linuxbrew_dir:
+        log("Linuxbrew directory: %s", g_linuxbrew_dir)
+        new_path_entry = os.path.join(g_linuxbrew_dir, 'bin')
+        log("Adding PATH entry: %s", new_path_entry)
+        add_path_entry(new_path_entry)
+    else:
+        log("Not using Linuxbrew")
+
+
+def using_linuxbrew() -> bool:
+    return get_linuxbrew_dir() is not None
+
+
+def set_linuxbrew_dir(linuxbrew_dir: str) -> None:
+    assert not g_detect_linuxbrew_called
+    global g_linuxbrew_dir
+    if g_linuxbrew_dir is not None and g_linuxbrew_dir != linuxbrew_dir:
+        raise ValueError(
+            "Linuxbrew directory already set to %s but trying to set it to %s",
+            g_linuxbrew_dir, linuxbrew_dir)
+
+    g_linuxbrew_dir = linuxbrew_dir

--- a/python/yugabyte_db_thirdparty/linuxbrew.py
+++ b/python/yugabyte_db_thirdparty/linuxbrew.py
@@ -32,12 +32,18 @@ g_linuxbrew_dir: Optional[str] = None
 g_detect_linuxbrew_called: bool = False
 
 
-def get_linuxbrew_dir() -> Optional[str]:
+def get_optional_linuxbrew_dir() -> Optional[str]:
     global g_detect_linuxbrew_called
     if not g_detect_linuxbrew_called:
         _detect_linuxbrew()
-        g_get_linuxbrew_dir_called = True
+        g_get_optional_linuxbrew_dir_called = True
     return g_linuxbrew_dir
+
+
+def get_linuxbrew_dir() -> str:
+    linuxbrew_dir = get_optional_linuxbrew_dir()
+    assert linuxbrew_dir is not None
+    return linuxbrew_dir
 
 
 def _detect_linuxbrew() -> None:
@@ -70,7 +76,7 @@ def _detect_linuxbrew() -> None:
 
 
 def using_linuxbrew() -> bool:
-    return get_linuxbrew_dir() is not None
+    return get_optional_linuxbrew_dir() is not None
 
 
 def set_linuxbrew_dir(linuxbrew_dir: str) -> None:


### PR DESCRIPTION
Relevant issue: https://github.com/yugabyte/yugabyte-db/issues/10920

Using Clang 12 that is natively compiled for the host OS (currently, RHEL 7 or 8 compatible distros) to build third-party dependencies using the same x86_64 Linuxbrew archive that we are currently using for the production GCC 5.5 based build. This will allow us to replace GCC 5.5 with Clang 12 and use modern C++ features.

We achieve this by specifying `-nostdinc` and `-nostdinc++` and specifying all the include directories manually. We also specify Linuxbrew's library directories both as `-L` and `-Wl,-rpath`. 

Boost's build system would add `-I/usr/include` to the compiler command line for some reason. We are working around this by activating our compiler wrapper and removing that argument from the command line. We are also using the compiler wrapper to validate the set of actual include files used and to verify that no include files from `/usr/include` are used.