### PR TITLE
Correctly disable cyrus-sasl in openldap

### DIFF
--- a/python/build_definitions/openldap.py
+++ b/python/build_definitions/openldap.py
@@ -33,9 +33,10 @@ class OpenLDAPDependency(Dependency):
     def build(self, builder: BuilderInterface) -> None:
         # build client only
         disabled_features = (
-            'slapd', 'bdb', 'hdb', 'mdb', 'monitor', 'relay', 'syncprov', 'cyrus-sasl'
+            'slapd', 'bdb', 'hdb', 'mdb', 'monitor', 'relay', 'syncprov'
         )
 
         builder.build_with_configure(
             builder.log_prefix(self),
-            extra_args=['--disable-' + feature for feature in disabled_features])
+            extra_args=['--disable-' + feature for feature in disabled_features] +
+                       ['--with-cyrus-sasl=no'])


### PR DESCRIPTION
OpenLDAP uses cyrus-sasl by default. 
When Kerberos is installed on the build machine, cyrus-sasl would use it and OpenLDAP would depend on Kerberos libraries.
Our Jenkins build machines do not have Kerberos, so the build fails if OpenLDAP depends on Kerberos.
Here we correctly turn off cyrus-sasl for OpenLDAP build to avoid having this dependency.