### PR TITLE
[yugabyte/yugabyte-db#13103] ncurses: Add terminfo default path

### DIFF
--- a/python/build_definitions/ncurses.py
+++ b/python/build_definitions/ncurses.py
@@ -26,9 +26,7 @@ class NCursesDependency(Dependency):
         self.copy_sources = True
 
     def build(self, builder: BuilderInterface) -> None:
-        extra_args = ['--with-shared']
-        if is_macos():
-            extra_args.append('--with-default-terminfo-dir=/usr/share/terminfo')
+        extra_args = ['--with-shared', '--with-default-terminfo-dir=/usr/share/terminfo']
         builder.build_with_configure(dep=self, extra_args=extra_args)
 
     def get_additional_leading_ld_flags(self, builder: 'BuilderInterface') -> List[str]:

--- a/python/build_definitions/ncurses.py
+++ b/python/build_definitions/ncurses.py
@@ -26,7 +26,10 @@ class NCursesDependency(Dependency):
         self.copy_sources = True
 
     def build(self, builder: BuilderInterface) -> None:
-        builder.build_with_configure(dep=self, extra_args=['--with-shared'])
+        extra_args = ['--with-shared']
+        if is_macos():
+            extra_args.append('--with-default-terminfo-dir=/usr/share/terminfo')
+        builder.build_with_configure(dep=self, extra_args=extra_args)
 
     def get_additional_leading_ld_flags(self, builder: 'BuilderInterface') -> List[str]:
         flags = super().get_additional_leading_ld_flags(builder)


### PR DESCRIPTION
Should get rid of
```
Cannot read termcap database;
using dumb terminal settings.
```
in ysqlsh.

Edit: Confirmed that this works by building my own ncurses lib and replacing the libncurses.6.dylib in 2.15.0.0-b11 macOS release:
```
$ curl -O https://downloads.yugabyte.com/releases/2.15.0.0/yugabyte-2.15.0.0-b11-darwin-x86_64.tar.gz
$ tar xvf yugabyte-2.15.0.0-b11-darwin-x86_64.tar.gz
$ cd yugabyte-2.15.0.0-b11-darwin-x86_64
$ bin/ysqlsh
ysqlsh (11.2-YB-2.15.0.0-b0)
Type "help" for help.

Cannot read termcap database;
using dumb terminal settings.
yugabyte=# ^D\q
$ cd ..
$ curl -O https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz
$ tar xvf ncurses-6.3.tar.gz
$ cd ncurses-6.3
$ LDFLAGS="-arch x86_64" CFLAGS="-arch x86_64" ./configure --with-default-terminfo-dir=/usr/share/terminfo --with-shared
$ make -j10
$ cp lib/libncurses.6.dylib ../yugabyte-2.15.0.0/lib/libncurses.6.dylib
$ ../yugabyte-2.15.0.0/bin/ysqlsh
ysqlsh (11.2-YB-2.15.0.0-b0)
Type "help" for help.

yugabyte=# ^D\q
```