### PR TITLE
Fix CentOS 7 TSAN Clang 13 build

### DIFF
--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -52,7 +52,7 @@ log_path=${log_dir}/${log_file_name}
 (
   cd "${log_dir}"
   for link_name in "${latest_log_links[@]}"; do
-    ln -sfT "${log_file_name}" "${link_name}"
+    ln -sf "${log_file_name}" "${link_name}"
   done
 )
 link_path_list_str=""

--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -67,13 +67,14 @@ echo
 echo "Logging to ${log_path} (linked to ${link_path_list_str})"
 echo
 
+# Cannot use |& redirection of both stdout and stderr due to the need to support Bash 3.
 (
   set -x
 
   # shellcheck disable=SC2086
   python3 "$YB_THIRDPARTY_DIR/python/yugabyte_db_thirdparty/yb_build_thirdparty_main.py" \
     "${build_thirdparty_args[@]}"
-) |& tee "${log_path}"
+) 2>&1 | tee "${log_path}"
 
 echo
 echo "Log saved to ${log_path}"


### PR DESCRIPTION
Needed to fix yugabyte/yugabyte-db#13615.

With Clang 13 and CentOS 7, the symbol __cxa_thread_atexit_impl in libcxxabi is referenced as a regular undefined symbol, not a weak symbol, leading to a runtime error. Explicitly set LIBCXXABI_HAS_CXA_THREAD_ATEXIT_IMPL as OFF in that case to avoid this problem. The resulting use of a weak symbol becomes consistent with what happens in non-sanitizer and ASAN builds, as well as on RHEL 8 based systems.

Also automatically save build log to a file in the ~/logs directory and create "latest" symlinks to it in build_thirdparty.sh.