### PR TITLE
Use C++20 for build on macOS when possible

### DIFF
--- a/python/build_definitions/icu4c.py
+++ b/python/build_definitions/icu4c.py
@@ -95,6 +95,13 @@ class Icu4cDependency(Dependency):
             return
         write_file(makefile_path, '\n'.join(makefile_lines) + '\n')
 
+    def get_additional_cxx_flags(self, builder: BuilderInterface) -> List[str]:
+        if is_macos():
+            llvm_major_version = builder.compiler_choice.get_llvm_major_version()
+            if llvm_major_version is not None and llvm_major_version < 13:
+                return ['-std=c++17']
+        return []
+
     def build(self, builder: BuilderInterface) -> None:
         configure_extra_args = [
             '--disable-samples',

--- a/python/build_definitions/icu4c.py
+++ b/python/build_definitions/icu4c.py
@@ -95,12 +95,12 @@ class Icu4cDependency(Dependency):
             return
         write_file(makefile_path, '\n'.join(makefile_lines) + '\n')
 
-    def get_additional_cxx_flags(self, builder: BuilderInterface) -> List[str]:
+    def get_cxx_version(self, builder: BuilderInterface) -> str:
         if is_macos():
             llvm_major_version = builder.compiler_choice.get_llvm_major_version()
             if llvm_major_version is not None and llvm_major_version < 13:
-                return ['-std=c++17']
-        return []
+                return '17'
+        return super().get_cxx_version(builder)
 
     def build(self, builder: BuilderInterface) -> None:
         configure_extra_args = [

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -513,7 +513,12 @@ class Builder(BuilderInterface):
 
         # The C++ standard must match CMAKE_CXX_STANDARD in the top-level CMakeLists.txt file in
         # the YugabyteDB source tree.
-        self.cxx_flags.append('-std=c++20')
+        std_cxx = '20'
+        if is_macos():
+            version = self.compiler_choice.get_llvm_major_version()
+            if version and version < 13:
+                std_cxx = '2a'
+        self.cxx_flags.append('-std=c++{}'.format(std_cxx))
 
         self.cxx_flags.append('-frtti')
 

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -947,7 +947,7 @@ class Builder(BuilderInterface):
         for flag in additional_flags:
             pos = flag.find('=')
             if pos != -1:
-                keys.insert(key[:pos])
+                keys.add(flag[:pos])
         result = []
         for flag in self.cxx_flags + self.get_effective_compiler_flags(dep):
             pos = flag.find('=')

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -513,12 +513,7 @@ class Builder(BuilderInterface):
 
         # The C++ standard must match CMAKE_CXX_STANDARD in the top-level CMakeLists.txt file in
         # the YugabyteDB source tree.
-        if is_linux():
-            self.cxx_flags.append('-std=c++20')
-        else:
-            # TODO: investigate why icu4c compilation fails with -std=c++20 when built on GitHub
-            # Actions macOS workers with Clang 12 (need to check macOS SDK version, etc.)
-            self.cxx_flags.append('-std=c++17')
+        self.cxx_flags.append('-std=c++20')
 
         self.cxx_flags.append('-frtti')
 

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -942,9 +942,19 @@ class Builder(BuilderInterface):
         return self.compiler_flags + dep.get_additional_compiler_flags(self)
 
     def get_effective_cxx_flags(self, dep: Dependency) -> List[str]:
-        return (self.cxx_flags +
-                self.get_effective_compiler_flags(dep) +
-                dep.get_additional_cxx_flags(self))
+        additional_flags = dep.get_additional_cxx_flags(self)
+        keys: Set[str] = set()
+        for flag in additional_flags:
+            pos = flag.find('=')
+            if pos != -1:
+                keys.insert(key[:pos])
+        result = []
+        for flag in self.cxx_flags + self.get_effective_compiler_flags(dep):
+            pos = flag.find('=')
+            if pos == -1 or flag[:pos] not in keys:
+                result.append(flag)
+        result += additional_flags
+        return result
 
     def get_effective_c_flags(self, dep: Dependency) -> List[str]:
         return (self.c_flags +

--- a/python/yugabyte_db_thirdparty/dependency.py
+++ b/python/yugabyte_db_thirdparty/dependency.py
@@ -11,7 +11,7 @@
 # under the License.
 
 import os
-from sys_detection import is_linux
+from sys_detection import is_linux, is_macos
 
 from build_definitions import ExtraDownload, VALID_BUILD_GROUPS
 from yugabyte_db_thirdparty.archive_handling import make_archive_name
@@ -91,6 +91,13 @@ class Dependency:
 
     def get_additional_cxx_flags(self, builder: 'BuilderInterface') -> List[str]:
         return []
+
+    def get_cxx_version(self, builder: 'BuilderInterface') -> str:
+        if is_macos():
+            version = builder.compiler_choice.get_llvm_major_version()
+            if version and version < 13:
+                return '2a'
+        return '20'
 
     def get_additional_leading_ld_flags(self, builder: 'BuilderInterface') -> List[str]:
         """


### PR DESCRIPTION
Previously, we used C++17 for building C++ code on macOS. This created certain problems with building YugabyteDB with precompiled headers.

In this commit, we are modifying the build to use C++2a on macOS for Clang 12, and C++20 for Clang 13 or later. For the icu4c library, as a special case, we build it with C++17 when using Clang 12 or earlier.

This complexity should go away when we upgrade to Clang 13 and later across the board.