### PR TITLE
Fix Abseil and TCMalloc lib file naming.

### DIFF
--- a/python/build_definitions/abseil.py
+++ b/python/build_definitions/abseil.py
@@ -33,11 +33,11 @@ class AbseilDependency(Dependency):
         builder.install_bazel_build_output(
                 dep=self,
                 src_file="libabsl_shared.so",
-                dest_file="absl_shared." + builder.shared_lib_suffix,
+                dest_file=f"libabsl.{builder.shared_lib_suffix}",
                 src_folder="absl",
                 is_shared=True)
         builder.install_bazel_build_output(
-                dep=self, src_file="absl_static.a", dest_file="absl_static.a",
+                dep=self, src_file="absl_static.a", dest_file="libabsl.a",
                 src_folder="absl", is_shared=False)
 
         # Copy headers, keeping the folder structure. https://stackoverflow.com/a/29457076.

--- a/python/build_definitions/tcmalloc.py
+++ b/python/build_definitions/tcmalloc.py
@@ -34,11 +34,11 @@ class TCMallocDependency(Dependency):
         builder.install_bazel_build_output(
                 dep=self,
                 src_file="libtcmalloc_shared.so",
-                dest_file=f"googletcmalloc_shared.{builder.shared_lib_suffix}",
+                dest_file=f"libgoogletcmalloc.{builder.shared_lib_suffix}",
                 src_folder="tcmalloc",
                 is_shared=True)
         builder.install_bazel_build_output(
-                dep=self, src_file="tcmalloc_static.a", dest_file="googletcmalloc_static.a",
+                dep=self, src_file="tcmalloc_static.a", dest_file="libgoogletcmalloc.a",
                 src_folder="tcmalloc", is_shared=False)
 
         # Copy headers.


### PR DESCRIPTION
Name lib files libabsl.so/a and libgoogletcmalloc.so/a.