### PR TITLE
Build curl without zstd (#159)

### DIFF
--- a/python/build_definitions/curl.py
+++ b/python/build_definitions/curl.py
@@ -35,7 +35,8 @@ class CurlDependency(Dependency):
             '--without-brotli',
             '--without-libidn2',
             '--without-librtmp',
-            '--without-nghttp2'
+            '--without-nghttp2',
+            '--without-zstd',
         ]
 
         builder.build_with_configure(dep=self, extra_args=extra_args)


### PR DESCRIPTION
curl 7.72.0 adds a dependency on zstd, which causes some AlmaLinux builds to break. Compiling without zstd fixes it.