### PR TITLE
Add local_archive option. Update README.md to Clang15.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # yugabyte-db-thirdparty
 
-This repository contains Python-based automation to build and package third-party dependencies that are needed to build YugabyteDB. We package these dependencies as GitHub releases so that they can be downloaded by YugabyteDB CI/CD systems without having to rebuild them every time. Here is an example of how to build yugabyte-db-thirdparty and then YugabyteDB with Clang 12.
+This repository contains Python-based automation to build and package third-party dependencies that are needed to build YugabyteDB. We package these dependencies as GitHub releases so that they can be downloaded by YugabyteDB CI/CD systems without having to rebuild them every time. Here is an example of how to build yugabyte-db-thirdparty and then YugabyteDB with Clang 15.
 
 ```bash
 cd ~/code
 git clone https://github.com/yugabyte/yugabyte-db-thirdparty.git
 cd yugabyte-db-thirdparty
-./build_thirdparty.sh --toolchain=llvm12
+./build_thirdparty.sh --toolchain=llvm15
 ```
 
 To use your local changes to yugabyte-db-thirdparty in a YugabyteDB build:
@@ -16,7 +16,7 @@ cd ~/code
 git clone https://github.com/yugabyte/yugabyte-db.git
 cd yugabyte-db
 export YB_THIRDPARTY_DIR=~/code/yugabyte-db-thirdparty
-./yb_build.sh --clang12
+./yb_build.sh --clang15
 ```
 
 The [ci.yml](https://github.com/yugabyte/yugabyte-db-thirdparty/blob/master/.github/workflows/ci.yml) GitHub Actions workflow file contains multiple operating system and compiler configurations that we build and test regularly. Take a look at the command lines used in that file to get an idea of various usable combinations of parameters to the `build_thirdparty.sh` script.
@@ -27,34 +27,48 @@ The third-party dependencies themselves are described, each in its own Python fi
 
 To modify some dependency (e.g. glog):
 * Look at the corresponding python file in build_definitions, e.g. https://github.com/yugabyte/yugabyte-db-thirdparty/blob/master/python/build_definitions/glog.py, to see where it is pulling the dependency from. Usually it is a GitHub repo, either the open-source upstream repo or our own fork.
-* In case of glog, it is https://github.com/yugabyte/glog. Fork that repo on GitHub, to e.g. https://github.com/yourgithubusername/glog. Make all the necessary changes in your fork, push changes to a branch on your fork, and create a tag, e.g. `0.4.0-yb-yourusername-1`. Push the tag to your fork.
-* Modify the dependency python file, i.e. glog.py in this case, to reference your own repo and tag:
-
+* In case of glog, it is https://github.com/yugabyte/glog. Fork that repo on GitHub, to e.g. https://github.com/yourgithubusername/glog. Clone your fork of the repo and make all the necessary changes in your local checkout.
+* To test locally, pass `local_archive` pointing to your clone path (`local_archive` is only meant for testing and should not be submitted in your PR):
 ```python
         super(GLogDependency, self).__init__(
             name='glog',
-            version='0.4.0-yb-yourusername-1',
-            url_pattern='https://github.com/yourgithubyusername/glog/archive/v{0}.tar.gz',
+            version='0.4.0-yb-1',
+            url_pattern='https://github.com/yugabyte/glog/archive/v{0}.tar.gz',
+            local_archive='~/path/to/glog',
+            build_group=BUILD_GROUP_INSTRUMENTED)
+```
+* When you are done with your changes to the dependency, e.g. glog, get them checked into our fork, i.e. yugabyte/glog on GitHub, and create the next "official" Yugabyte tag for that dependency, e.g. 0.4.0-yb-2 (we usually add a `-yb-N` suffix to the upstream version).
+* Reference the updated tag from the version field in the dependency's python file as shown below. **Remember to remove `local_archive`.**
+```python
+        super(GLogDependency, self).__init__(
+            name='glog',
+            version='0.4.0-yb-2', # Note the updated tag
+            url_pattern='https://github.com/yugabyte/glog/archive/v{0}.tar.gz',
             build_group=BUILD_GROUP_INSTRUMENTED)
 ```
 
 * Rebuild thirdparty (`--add-checksum` so it would auto-add the checksum for your archive):
 
 ```
-./build_thirdparty.sh --add-checksum
+./build_thirdparty.sh --toolchain=llvm15 --add-checksum
 ```
-
-* When you are done with your changes to the dependency, e.g. glog, get them checked into our fork, i.e. yugabyte/glog on GitHub, and create the next "official" Yugabyte tag for that dependency, e.g. 0.4.0-yb-2 (we usually add a `-yb-N` suffix to the upstream version). Then in your PR to yugabyte-db-thirdparty, reference that tag from the dependency's python file as shown above.
+* Create a PR in yugabyte-db-thirdparty with a descriptive commit message.
 
 ## Ensuring a clean build
-
 By default, we don't use separate directories for different "build types" in yugabyte-db-thirdparty unlike we do in YugabyteDB. Therefore, when changing to a different compiler family, compiler version, compiler flags, etc., it would be safest to remove build output before rebuilding:
 
 ```
 rm -rf build installed
 ```
 
-However, during development, `--per-build-dirs` introduces per-built type subdirectories under `build` and `installed` directories.
+If you only need to clean the built files and not the installed files (or are ok with overwriting the installed files), you can use the `clean_thirdparty.sh` script. With no arguments, `clean_thirdparty.sh` will clean all dependencies. To only clean certain dependencies, pass them as command line arguments. For example, to clean only Abseil and TCMalloc:
+```
+clean_thirdparty.sh abseil tcmalloc
+```
+
+
+## Per-build type directories
+During development, `--per-build-dirs` introduces per-built type subdirectories under `build` and `installed` directories. Note that `--per-build-dirs` does not work properly with the yugabyte-db build. You must build without `--per-build-dirs` for that.
 
 ```
 $ ls build
@@ -89,8 +103,8 @@ mkdir -p ~/logs
 ### Linux aarch64
 
 ```
-export YB_THIRDPARTY_ARCHIVE_NAME_SUFFIX=almalinux8-aarch64-clang12
-export YB_BUILD_THIRDPARTY_EXTRA_ARGS="--toolchain=llvm12 --expected-major-compiler-version=12"
+export YB_THIRDPARTY_ARCHIVE_NAME_SUFFIX=almalinux8-aarch64-clang15
+export YB_BUILD_THIRDPARTY_EXTRA_ARGS="--toolchain=llvm15 --expected-major-compiler-version=15"
 rm -rf venv
 ./clean_thirdparty.sh --all
 mkdir -p ~/logs
@@ -100,8 +114,8 @@ mkdir -p ~/logs
 ### Amazon Linux 2 aarch64
 
 ```
-export YB_THIRDPARTY_ARCHIVE_NAME_SUFFIX=amzn2-aarch64-clang12
-export YB_BUILD_THIRDPARTY_EXTRA_ARGS="--toolchain=llvm12 --expected-major-compiler-version=12"
+export YB_THIRDPARTY_ARCHIVE_NAME_SUFFIX=amzn2-aarch64-clang15
+export YB_BUILD_THIRDPARTY_EXTRA_ARGS="--toolchain=llvm15 --expected-major-compiler-version=15"
 rm -rf venv
 ./clean_thirdparty.sh --all
 mkdir -p ~/logs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To modify some dependency (e.g. glog):
             name='glog',
             version='0.4.0-yb-1',
             url_pattern='https://github.com/yugabyte/glog/archive/v{0}.tar.gz',
-            local_archive='~/path/to/glog',
+            local_archive='/path/to/glog',
             build_group=BUILD_GROUP_INSTRUMENTED)
 ```
 * When you are done with your changes to the dependency, e.g. glog, get them checked into our fork, i.e. yugabyte/glog on GitHub, and create the next "official" Yugabyte tag for that dependency, e.g. 0.4.0-yb-2 (we usually add a `-yb-N` suffix to the upstream version).

--- a/python/yugabyte_db_thirdparty/dependency.py
+++ b/python/yugabyte_db_thirdparty/dependency.py
@@ -32,6 +32,7 @@ class Dependency:
     license: Optional[str]
     mkdir_only: bool
     archive_name: Optional[str]
+    local_archive: Optional[str]
 
     # For dependencies built with configure/autotools, where out-of-source build is not possible,
     # this tells the initial step to create separate build directories for shared and static builds.
@@ -45,7 +46,8 @@ class Dependency:
             build_group: str,
             archive_name_prefix: Optional[str] = None,
             license: Optional[str] = None,
-            mkdir_only: bool = False) -> None:
+            mkdir_only: bool = False,
+            local_archive: Optional[str] = None) -> None:
         self.name = name
         self.version = version
         self.dir_name = '{}-{}'.format(name, version)
@@ -61,6 +63,7 @@ class Dependency:
         if not mkdir_only:
             self.archive_name = make_archive_name(
                 archive_name_prefix or name, version, self.download_url)
+        self.local_archive = local_archive
 
         self.patch_version = 0
         self.extra_downloads = []

--- a/python/yugabyte_db_thirdparty/download_manager.py
+++ b/python/yugabyte_db_thirdparty/download_manager.py
@@ -317,6 +317,9 @@ class DownloadManager:
             # Just create an empty directory with the specified name.
             log("Creating %s", src_path)
             mkdir_if_missing(src_path)
+        elif dep.local_archive:
+            log("Copying from local archive at %s to %s", dep.local_archive, src_path)
+            shutil.copytree(dep.local_archive, src_path)
         else:
             download_url = dep.download_url
             log("Download URL: %s", download_url)


### PR DESCRIPTION
This PR adds support for building a dependency from a local checkout of the repo instead of from a tag with the `local_archive` option. This avoids the annoying loop of having to push tags to a fork and re-download to test build changes.

Tested by:
```
build_thirdparty.sh --toolchain=llvm15
clean_thirdparty.sh glog
<Add the local archive glog folder>
build_thirdparty.sh --toolchain=llvm15
```

It also updates the readme to:
 - Reference Clang 15 instead of Clang 12
 - Describe how to use the new `local_archive` option
 - Describe `clean_thirdparty.sh`