### PR TITLE
Patch openldap so it does not build docs

### DIFF
--- a/patches/openldap-do-not-build-docs.patch
+++ b/patches/openldap-do-not-build-docs.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index 0dddeca..e132990 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -13,7 +13,7 @@
+ ## top-level directory of the distribution or, alternatively, at
+ ## <http://www.OpenLDAP.org/license.html>.
+
+-SUBDIRS= include libraries clients servers tests doc
++SUBDIRS= include libraries clients servers tests
+ CLEANDIRS=
+ INSTALLDIRS=
+

--- a/python/build_definitions/openldap.py
+++ b/python/build_definitions/openldap.py
@@ -24,6 +24,8 @@ class OpenLDAPDependency(Dependency):
               'https://github.com/yugabyte/openldap/archive/OPENLDAP_REL_ENG_{}.tar.gz',
               BUILD_GROUP_COMMON)
         self.copy_sources = True
+        self.patch_version = 1
+        self.patches = ['openldap-do-not-build-docs.patch']
 
     def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
         llvm_major_version = builder.compiler_choice.get_llvm_major_version()


### PR DESCRIPTION
The build might fail on certain macOS arm64 systems when trying to build OpenLDAP docs because of the dependency on the soelim tool. Patch OpenLDAP to not build the docs at all.