### PR TITLE
Use the branch file for determining the tag [skip ci]

### DIFF
--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -155,7 +155,17 @@ fi
 
 original_repo_dir=$PWD
 git_sha1=$( git rev-parse HEAD )
-tag=v$( date +%Y%m%d%H%M%S )-${git_sha1:0:10}
+
+branch_file_path="$YB_THIRDPARTY_DIR/branch.txt"
+branch_name=""
+if [[ -f ${branch_file_path} ]]; then
+  branch_name=$(<"${branch_file_path}")
+fi
+tag=v
+if [[ -n ${branch_name} ]]; then
+  tag+="${branch_name}-"
+fi
+tag+=$( date +%Y%m%d%H%M%S )-${git_sha1:0:10}
 
 archive_dir_name=yugabyte-db-thirdparty-$tag
 if [[ -z ${YB_THIRDPARTY_ARCHIVE_NAME_SUFFIX:-} ]]; then


### PR DESCRIPTION
The branch file `branch.txt` is used by the release branch build logic described at https://github.com/yugabyte/yugabyte-db-thirdparty#setting-up-a-new-release-version-branch . While this file is absent in the master branch, it will be added in new release branches, and the logic to handle it will already be there due to this commit.