### PR TITLE
Compile opentelemetery libraries for distributed tracing of YSQL queries 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: macos-x86_64
-            os: macos-10.15
+            os: macos-11.7
             docker_image:
             build_thirdparty_args:
 

--- a/python/build_definitions/otel.py
+++ b/python/build_definitions/otel.py
@@ -1,0 +1,34 @@
+#
+# Copyright (c) YugaByte, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations
+# under the License.
+#
+import os
+
+from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
+
+
+class OtelDependency(Dependency):
+    def __init__(self) -> None:
+        super(OtelDependency, self).__init__(
+            name='opentelemetry-cpp',
+            version='1.8.2.v1',
+            url_pattern='https://github.com/vrajat/opentelemetry-cpp/archive/refs/tags/v{0}.tar.gz',
+            build_group=BUILD_GROUP_INSTRUMENTED)
+        self.copy_sources = False
+
+    def build(self, builder: BuilderInterface) -> None:
+        builder.build_with_cmake(self,
+                                 ['-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+                                  '-DBUILD_SHARED_LIBS=ON',
+                                  '-DWITH_OTLP=ON',
+                                  '-DWITH_BENCHMARK=OFF',
+                                  "-DOTELCPP_PROTO_PATH={path}".format(path=os.path.join(builder.fs_layout.tp_src_dir, "opentelemetry-proto-0.1.2"))])

--- a/python/build_definitions/otel_proto.py
+++ b/python/build_definitions/otel_proto.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) YugaByte, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations
+# under the License.
+#
+
+from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
+
+
+class OtelProtoDependency(Dependency):
+    def __init__(self) -> None:
+        super(OtelProtoDependency, self).__init__(
+            name='opentelemetry-proto',
+            version='0.1.2',
+            url_pattern='https://github.com/vrajat/opentelemetry-proto/archive/refs/tags/v{0}.tar.gz',
+            build_group=BUILD_GROUP_INSTRUMENTED)
+        self.copy_sources = False
+
+    def build(self, builder: BuilderInterface) -> None:
+        pass

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -381,6 +381,8 @@ class Builder(BuilderInterface):
                 'cassandra_cpp_driver',
                 'krb5',
                 'hdrhistogram',
+                'otel_proto',
+                'otel'
             ])
 
     def select_dependencies_to_build(self) -> None:


### PR DESCRIPTION
[Opentelemetry](https://opentelemetry.io/) is a CNCF project that defines a standard for distributed tracing. The project also provides API and SDKs to instrument code in various languages including C++. It's license is Apache 2.0 and permission has been given to use it in Yugabyte.

This commit compiles the latest (v1.9.0) version of opentelemetry-cpp. This version uses a protobuf feature experimental_allow_proto3_optional that is not supported by the protobuf version (v3.5.1) used in Yugabyte. Therefore a couple of patches to remove the usage of the feature has also been added.