### PR TITLE
Draft: Revert "Do not rely on patch marker file if local_archive is set for a dependency."

### DIFF
--- a/python/build_definitions/curl.py
+++ b/python/build_definitions/curl.py
@@ -14,7 +14,7 @@
 
 from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
 
-# Dummy change to trigger CI.
+
 class CurlDependency(Dependency):
     def __init__(self) -> None:
         super(CurlDependency, self).__init__(
@@ -29,6 +29,7 @@ class CurlDependency(Dependency):
                              'pop3', 'imap', 'smtp', 'gopher', 'manual', 'librtmp', 'ipv6']
         extra_args = ['--disable-' + feature for feature in disabled_features]
 
+        # Hopefully a comment here won't fail pycodestyle.
         extra_args.append('--with-ssl=%s' % builder.get_openssl_dir())
         extra_args.append('--with-zlib=%s' % builder.get_openssl_dir())
         extra_args += [

--- a/python/build_definitions/curl.py
+++ b/python/build_definitions/curl.py
@@ -14,7 +14,7 @@
 
 from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
 
-
+# Dummy change to trigger CI.
 class CurlDependency(Dependency):
     def __init__(self) -> None:
         super(CurlDependency, self).__init__(

--- a/python/yugabyte_db_thirdparty/download_manager.py
+++ b/python/yugabyte_db_thirdparty/download_manager.py
@@ -307,7 +307,7 @@ class DownloadManager:
                 src_path, 'patchmarker-version{}-{}patches'.format(
                     dep.patch_version, len(dep.patches)))
         log("Patch marker file: %s", patch_marker_file_path)
-        if os.path.exists(patch_marker_file_path) and not dep.local_archive:
+        if os.path.exists(patch_marker_file_path):
             log("Patch marker file %s already exists, skipping download", patch_marker_file_path)
             return
 
@@ -319,7 +319,6 @@ class DownloadManager:
             mkdir_p(src_path)
         elif dep.local_archive:
             log("Copying from local archive at %s to %s", dep.local_archive, src_path)
-            shutil.rmtree(src_path, ignore_errors=True)
             shutil.copytree(dep.local_archive, src_path)
         else:
             download_url = dep.download_url


### PR DESCRIPTION
Reverts yugabyte/yugabyte-db-thirdparty#199

Just trying to revert the commit to see if this is causing the macOS build to break in https://github.com/yugabyte/yugabyte-db-thirdparty/pull/205.