### PR TITLE
[skip ci] Updating macos version in ci build script to 11 from 10.15 …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: macos-x86_64
-            os: macos-10.15
+            os: macos-11
             docker_image:
             build_thirdparty_args:
 

--- a/yb-thirdparty-common.sh
+++ b/yb-thirdparty-common.sh
@@ -75,7 +75,6 @@ ensure_correct_mac_architecture() {
   fi
   if [[ $YB_TARGET_ARCH != "x86_64" && $YB_TARGET_ARCH != "arm64" ]]; then
     fatal "Invalid value of YB_TARGET_ARCH on macOS (expected x86_64 or arm64): $YB_TARGET_ARCH"
-    exit 1
   fi
   export YB_TARGET_ARCH
   local actual_arch


### PR DESCRIPTION
…(#192)

* Updating macos version in ci build script to 11 from 10.15, which is no longer supported

* Removed exit 1 line in thirdparty-common for macos

---------