### PR TITLE
Fix undefined symbol: __cxa_thread_atexit_impl under CentOS 7 with ASAN

### DIFF
--- a/python/build_definitions/llvm_libcxx.py
+++ b/python/build_definitions/llvm_libcxx.py
@@ -167,7 +167,7 @@ class LibCxxWithAbiDependency(LlvmLibCxxDependencyBase):
 
     def get_additional_cmake_args(self, builder: BuilderInterface) -> List[str]:
         args = ['-DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi']
-        if builder.build_type == BuildType.TSAN:
+        if builder.build_type in [BuildType.ASAN, BuildType.TSAN]:
             local_sys_conf = sys_detection.local_sys_conf()
             if local_sys_conf.is_redhat_family() and int(local_sys_conf.short_os_version()) == 7:
                 # On CentOS 7, we want to prevent libcxxabi build system from deciding that the


### PR DESCRIPTION
We already do this workaround for TSAN on CentOS 7. Extend it to ASAN as well.

CI build types: centos7-x86_64-clang15, centos7-x86_64-clang15-full-lto, centos7-x86_64-clang16, centos7-x86_64-clang16-full-lto