### PR TITLE
Upgrade CI builds to macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: macos-x86_64
-            os: macos-11
+            os: macos-12
             docker_image:
             build_thirdparty_args:
 


### PR DESCRIPTION
macos-11 is near EOL and YBDB is migrated to macos-12 builds for future releases.
yugabyte/yugabyte-db#19454