### PR TITLE
Manually install hub for macOS builds

### DIFF
--- a/.github/workflows/macos_build.sh
+++ b/.github/workflows/macos_build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-brew install autoconf automake pkg-config shellcheck
+brew install autoconf automake pkg-config shellcheck hub
 dirs=( /opt/yb-build/{thirdparty,brew,tmp} )
 sudo mkdir -p "${dirs[@]}"
 sudo chmod 777 "${dirs[@]}"


### PR DESCRIPTION
Fix `./build_and_release.sh: line 229: hub: command not found` error in macOS builds due to `hub` being removed from out-of-the-box macOS runners.