### PR TITLE
[BACKPORT 2.18] Upgrade CI builds to macos-12 (#237)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           # ---------------------------------------------------------------------------------------
 
           - name: macos-x86_64
-            os: macos-11
+            os: macos-12
             docker_image:
             build_thirdparty_args:
 


### PR DESCRIPTION
macos-11 is near EOL and YBDB is migrated to macos-12 builds for future
releases.
https://github.com/yugabyte/yugabyte-db/issues/19454