### PR TITLE
Do not create empty files in place of Intel oneAPI headers

### DIFF
--- a/python/yugabyte_db_thirdparty/intel_oneapi.py
+++ b/python/yugabyte_db_thirdparty/intel_oneapi.py
@@ -313,7 +313,10 @@ class IntelOneAPIInstallation:
                 rel_to_include_dir_path = get_path_rel_to_include_dir(actual_include_file_path)
                 dest_path = os.path.join(include_install_dir, rel_to_include_dir_path)
                 file_util.mkdir_p(os.path.dirname(dest_path))
-                file_util.copy_file_or_simple_symlink(tag_file_path, dest_path)
+
+                # It is important that we don't copy the tag file, which has zero size, but the
+                # actual include file.
+                file_util.copy_file_or_simple_symlink(actual_include_file_path, dest_path)
 
     def create_package(self, dest_dir: str) -> None:
         tmp_dir = tempfile.mkdtemp(prefix='intel_oneapi_package_')


### PR DESCRIPTION
A bugfix for an omission in f4226c3d4b913bbc150e4767b80603b2b82fb568, to make the DiskANN dependency usable.