### PR TITLE
[2.18] Revert "[2.18] Compile libev with EV_USE_EVENTFD=0 (#269)"

### DIFF
--- a/python/build_definitions/libev.py
+++ b/python/build_definitions/libev.py
@@ -29,6 +29,3 @@ class LibEvDependency(Dependency):
 
     def use_cppflags_env_var(self) -> bool:
         return True
-
-    def get_preprocessor_flags(self) -> List[str]:
-        return ['-DEV_USE_EVENTFD=0']

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -547,8 +547,6 @@ class Builder(BuilderInterface):
         if self.build_type == BUILD_TYPE_TSAN:
             self.compiler_flags += TSAN_COMPILER_FLAGS
 
-        self.preprocessor_flags.extend(dep.get_preprocessor_flags())
-
     def add_linuxbrew_flags(self) -> None:
         if using_linuxbrew():
             lib_dir = os.path.join(get_linuxbrew_dir(), 'lib')

--- a/python/yugabyte_db_thirdparty/dependency.py
+++ b/python/yugabyte_db_thirdparty/dependency.py
@@ -173,9 +173,3 @@ class Dependency:
         This function only affects dependencies built with configure (autotools), not with CMake.
         '''
         return False
-
-    def get_preprocessor_flags(self) -> List[str]:
-        '''
-        These flags are added to the end of CPPFLAGS (C preprocessor flags).
-        '''
-        return []


### PR DESCRIPTION
This reverts commit 9474d3297544b0e1968f24b09fb48ca9debbb74a, since we are not proceeding with eventfd-disabled libev.