### PR TITLE
Make `build-type` option actually work

### DIFF
--- a/python/yugabyte_db_thirdparty/cmd_line_args.py
+++ b/python/yugabyte_db_thirdparty/cmd_line_args.py
@@ -41,8 +41,7 @@ def parse_cmd_line_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=sys.argv[0])
     parser.add_argument('--build-type',
                         default=None,
-                        type=str,
-                        action=enum_action(BuildType),
+                        action=enum_action(BuildType, str.lower),
                         help='Build only the third-party dependencies of the given type')
     parser.add_argument('--skip-sanitizers',
                         action='store_true',


### PR DESCRIPTION
Currently, the `build-type` option does not work at all and it's impossible to set it to anything.

Removing `type=str` makes it actually work.

Also, adds `str.lower` normalizer, so it's possible to use it with yugabyte-db main builder, which uses `uninstrumented` (lowercase) as an option.