### PR TITLE
WIP Add clang18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,11 @@ jobs:
             architecture: x86_64
 
           # Clang 18
-          # TODO: enable ASAN/TSAN for Clang 18.
           - name: amzn2-x86_64-clang18
             runs_on: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_amazonlinux2_x86_64:v2024-09-13T18_52_53
             build_thirdparty_args: >-
               --toolchain=llvm18
-              --skip-sanitizers
             architecture: x86_64
 
           - name: amzn2-x86_64-clang18-full-lto
@@ -141,7 +139,6 @@ jobs:
             build_thirdparty_args: >-
               --toolchain=llvm18
               --lto=full
-              --skip-sanitizers
             architecture: x86_64
 
           # ---------------------------------------------------------------------------------------
@@ -178,13 +175,11 @@ jobs:
             architecture: x86_64
 
           # Clang/LLVM 18
-          # TODO: enable ASAN/TSAN for Clang 18.
           - name: almalinux8-x86_64-clang18
             runs_on: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.
             docker_image: yugabyteci/yb_build_infra_almalinux8_x86_64:v2024-09-20T20_33_55
             build_thirdparty_args: >-
               --toolchain=llvm18
-              --skip-sanitizers
             architecture: x86_64
 
           # ---------------------------------------------------------------------------------------
@@ -254,14 +249,12 @@ jobs:
             docker_image: yugabyteci/yb_build_infra_amazonlinux2_aarch64:v2024-09-13T18_54_13
             build_thirdparty_args: >-
               --toolchain=llvm18
-              --skip-sanitizers
 
           - name: amzn2-aarch64-clang18-full-lto
             runs_on: ubuntu-24.04-aarch64-4core-16gb
             docker_image: yugabyteci/yb_build_infra_amazonlinux2_aarch64:v2024-09-13T18_54_13
             build_thirdparty_args: >-
               --toolchain=llvm18
-              --skip-sanitizers
               --lto=full
 
     steps:

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -824,10 +824,12 @@ class Builder(BuilderInterface):
 
             for command_item in compile_commands:
                 command_args = command_item['command'].split()
+                if command_args[-1].endswith('.S'):
+                    # Compiling assembly, skip check.
+                    continue
                 if self.build_type == BuildType.ASAN:
-                    if not command_args[-1].endswith('.S'):
-                        assert_list_contains(command_args, '-fsanitize=address')
-                        assert_list_contains(command_args, '-fsanitize=undefined')
+                    assert_list_contains(command_args, '-fsanitize=address')
+                    assert_list_contains(command_args, '-fsanitize=undefined')
                 if self.build_type == BuildType.TSAN:
                     assert_list_contains(command_args, '-fsanitize=thread')
 

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -825,8 +825,9 @@ class Builder(BuilderInterface):
             for command_item in compile_commands:
                 command_args = command_item['command'].split()
                 if self.build_type == BuildType.ASAN:
-                    assert_list_contains(command_args, '-fsanitize=address')
-                    assert_list_contains(command_args, '-fsanitize=undefined')
+                    if not command_args[-1].endswith('.S'):
+                        assert_list_contains(command_args, '-fsanitize=address')
+                        assert_list_contains(command_args, '-fsanitize=undefined')
                 if self.build_type == BuildType.TSAN:
                     assert_list_contains(command_args, '-fsanitize=thread')
 


### PR DESCRIPTION
Enable clang18 build on sanitizers. 

llvm_libcxx_with_abi compiles a few assembly files (.S), and we were looking for certain flags (-fsanitize=address, -fsanitize=thread) when building for sanitizers, which did not appear when assembling those files. Check was modified to ignore assembly files since the flags don't apply for them anyways.