### PR TITLE
[2.20] Add almalinux8 aarch64 clang16 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,23 @@ jobs:
               --expected-major-compiler-version=16
               --lto=full
 
+          - name: almalinux8-aarch64-clang16
+            os: ubuntu-24.04-aarch64-4core-16gb
+            docker_image: yugabyteci/yb_build_infra_almalinux8_aarch64:v2024-09-20T23_59_06
+            build_thirdparty_args: >-
+              --toolchain=llvm16
+              --expected-major-compiler-version=16
+              --skip-sanitizers
+
+          - name: almalinux8-aarch64-clang16-full-lto
+            os: ubuntu-24.04-aarch64-4core-16gb
+            docker_image: yugabyteci/yb_build_infra_almalinux8_aarch64:v2024-09-20T23_59_06
+            build_thirdparty_args: >-
+              --toolchain=llvm16
+              --expected-major-compiler-version=16
+              --skip-sanitizers
+              --lto=full
+
           # Clang/LLVM 17
           - name: almalinux8-x86_64-clang17
             os: ubuntu-20.04  # Ubuntu 20.04 is for the top-level VM only. We use Docker in it.


### PR DESCRIPTION
CentOS 7 builds were removed with #290, but we are still using the centos7-aarch64-clang16 builds for almalinux8 aarch64 clang16 builds, since there were no other aarch64 clang16 builds available. Adding almalinux8-aarch64-clang16 builds so that aarch64 clang16 builds are available.