### PR TITLE
[2024.1] Fix build name for almalinux8 aarch64 clang17 LTO build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
               --toolchain=llvm17
               --expected-major-compiler-version=17
 
-          - name: almalinux8-aarch64-clang17
+          - name: almalinux8-aarch64-clang17-full-lto
             os: ubuntu-24.04-aarch64-4core-16gb
             docker_image: yugabyteci/yb_build_infra_almalinux8_aarch64:v2024-09-20T23_59_06
             build_thirdparty_args: >-


### PR DESCRIPTION
Fix build name for LTO build for almalinux8/aarch64/clang17 from almalinux8-aarch64-clang17 (conflicts with non-LTO build) to almalinux8-aarch64-clang17-full-lto.