### PR TITLE
[DEVOPS-3278] Move thirdparty builds off of amzn2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,15 @@ jobs:
           # in test code.
           fetch-depth: 0
 
+      # Python version really only matters in the non-docker cases (macos), but it should match
+      # the version used in the docker images, for a common requirements_frozen.txt.
+      # The linux images (from build-infra repo) should be updated to newer python and this version
+      # updated to match.
+      - name: PythonVer
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
       - name: Build
         run: .github/workflows/github_actions_build.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,8 @@ jobs:
       # the version used in the docker images, for a common requirements_frozen.txt.
       # The linux images (from build-infra repo) should be updated to newer python and this version
       # updated to match.
+      # This action puts python and python3.9 in path, but python3 is still latest version.
+      # See setting in .github/workflows/macos_build.sh
       - name: PythonVer
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
       - name: PythonVer
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Build
         run: .github/workflows/github_actions_build.sh

--- a/.github/workflows/macos_build.sh
+++ b/.github/workflows/macos_build.sh
@@ -6,4 +6,6 @@ brew install autoconf automake pkg-config shellcheck hub
 dirs=( /opt/yb-build/{thirdparty,brew,tmp} )
 sudo mkdir -p "${dirs[@]}"
 sudo chmod 777 "${dirs[@]}"
+
+export PYTHON="python3.9"
 ./build_and_release.sh

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -159,7 +159,10 @@ tools_to_show_versions=(
   cmake
   pkg-config
   python3
+  python3.9
+  python
 )
+echo "path: $PATH"
 
 if [[ $OSTYPE == darwin* ]]; then
   tools_to_show_versions+=( shasum )

--- a/build_and_release.sh
+++ b/build_and_release.sh
@@ -158,11 +158,8 @@ tools_to_show_versions=(
   autoreconf
   cmake
   pkg-config
-  python3
-  python3.9
-  python
+  "${PYTHON:-python3}"
 )
-echo "path: $PATH"
 
 if [[ $OSTYPE == darwin* ]]; then
   tools_to_show_versions+=( shasum )

--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -67,7 +67,8 @@ echo
 echo "Logging to ${log_path} (linked to ${link_path_list_str})"
 echo
 
-cmd=( python3 "${YB_THIRDPARTY_DIR}/python/yugabyte_db_thirdparty/yb_build_thirdparty_main.py" )
+cmd=( ${PYTHON:-python3}
+      "${YB_THIRDPARTY_DIR}/python/yugabyte_db_thirdparty/yb_build_thirdparty_main.py" )
 if [[ ${#build_thirdparty_args[@]} -gt 0 ]]; then
   cmd+=( "${build_thirdparty_args[@]}" )
 fi

--- a/build_thirdparty.sh
+++ b/build_thirdparty.sh
@@ -67,7 +67,7 @@ echo
 echo "Logging to ${log_path} (linked to ${link_path_list_str})"
 echo
 
-cmd=( ${PYTHON:-python3}
+cmd=( "${PYTHON:-python3}"
       "${YB_THIRDPARTY_DIR}/python/yugabyte_db_thirdparty/yb_build_thirdparty_main.py" )
 if [[ ${#build_thirdparty_args[@]} -gt 0 ]]; then
   cmd+=( "${build_thirdparty_args[@]}" )

--- a/yb-thirdparty-common.sh
+++ b/yb-thirdparty-common.sh
@@ -43,7 +43,7 @@ compute_sha256sum() {
 
 activate_virtualenv() {
   if [[ ! -d $YB_THIRDPARTY_DIR/venv ]]; then
-    ${PYTHON:-python3} -m venv "$YB_THIRDPARTY_DIR/venv"
+    "${PYTHON:-python3}" -m venv "$YB_THIRDPARTY_DIR/venv"
   fi
   set +u
   # shellcheck disable=SC1090

--- a/yb-thirdparty-common.sh
+++ b/yb-thirdparty-common.sh
@@ -43,7 +43,7 @@ compute_sha256sum() {
 
 activate_virtualenv() {
   if [[ ! -d $YB_THIRDPARTY_DIR/venv ]]; then
-    python3 -m venv "$YB_THIRDPARTY_DIR/venv"
+    ${PYTHON:-python3} -m venv "$YB_THIRDPARTY_DIR/venv"
   fi
   set +u
   # shellcheck disable=SC1090


### PR DESCRIPTION
While amzn2 does not go EOL until mid-2025, it is no longer supported on
YBDB releases beyond 2.20. YBDB builds on master branch build on later
OS, so are not compatible with older glibc.

Thirdparty dependency builds on amzn2 are still supported on the 2.20
branch of this repo.