### PR TITLE
Disable alignment for bson types

### DIFF
--- a/python/build_definitions/bson.py
+++ b/python/build_definitions/bson.py
@@ -30,7 +30,8 @@ class BsonDependency(Dependency):
                 '-DENABLE_MONGOC=OFF',
                 '-DMONGOC_ENABLE_ICU=OFF'
                 '-DENABLE_ICU=OFF',
-                '-DENABLE_ZSTD=OFF',]
+                '-DENABLE_ZSTD=OFF',
+                '-DENABLE_EXTRA_ALIGNMENT=OFF']
 
     def build(self, builder: BuilderInterface) -> None:
         builder.build_with_cmake(self, shared_and_static=True)


### PR DESCRIPTION
PG15 which is what yb is currently based off of does not support aligned memory allocations. The DocumentDB extension also uses non aligned memory for storing the bson type in a few places. When the type is natively used in DocDB there will also be no guarantee that the memory is aligned. Hence disabling alignment.