### PR TITLE
[skip ci] Bump llvm-installer version to use PGO-enabled clang

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -17,7 +17,7 @@ importlib-resources==6.1.0
 jaraco.classes==3.3.0
 jeepney==0.8.0
 keyring==24.2.0
-llvm-installer==1.4.10
+llvm-installer==1.4.11
 markdown-it-py==3.0.0
 mdurl==0.1.2
 more-itertools==10.1.0


### PR DESCRIPTION
Bump llvm-installer to use PGO-enabled clang build.

yugabyte-db-thirdparty build (on c7a.4xlarge):

`./clean_thirdparty.sh --all && time ./build_thirdparty.sh --toolchain=llvm19 --skip-sanitizers`
- real: 17m34s -> 15m51s (-10%)
- user: 53m15s -> 44m45s (-16%)