### PR TITLE
Enable hardware-accelerated CRC32C in Abseil and TCMalloc builds

### DIFF
--- a/python/build_definitions/abseil.py
+++ b/python/build_definitions/abseil.py
@@ -14,6 +14,7 @@
 
 from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
 import os
+import platform
 
 
 class AbseilDependency(Dependency):
@@ -26,6 +27,14 @@ class AbseilDependency(Dependency):
             build_group=BuildGroup.POTENTIALLY_INSTRUMENTED)
         self.copy_sources = True
         self.bazel_project_subdir_name = 'com_google_absl'
+
+    def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
+        if platform.uname().machine == 'x86_64':
+            # Enable SSE4.2 and PCLMULQDQ so that Abseil's CRC32C implementation uses hardware
+            # acceleration (CRC32 instruction + carry-less multiply for large-buffer folding)
+            # instead of falling back to a software table-based implementation.
+            return ['-msse4.2', '-mpclmul']
+        return []
 
     def build(self, builder: BuilderInterface) -> None:
         log_prefix = builder.log_prefix(self)

--- a/python/build_definitions/tcmalloc.py
+++ b/python/build_definitions/tcmalloc.py
@@ -15,6 +15,7 @@
 from yugabyte_db_thirdparty.build_definition_helpers import *  # noqa
 import glob
 import os
+import platform
 
 
 class TCMallocDependency(Dependency):
@@ -53,6 +54,13 @@ class TCMallocDependency(Dependency):
 
     def set_abseil_source_dir_basename(self, abseil_src_dir_name: str) -> None:
         self.abseil_src_dir_name = abseil_src_dir_name
+
+    def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
+        if platform.uname().machine == 'x86_64':
+            # TCMalloc builds Abseil from source via Bazel local_repository. Enable SSE4.2 and
+            # PCLMULQDQ so that Abseil's CRC32C uses hardware acceleration in this context too.
+            return ['-msse4.2', '-mpclmul']
+        return []
 
     def get_additional_cxx_flags(self, builder: 'BuilderInterface') -> List[str]:
         cxx_flags = []


### PR DESCRIPTION
## Summary

- Add `-msse4.2` and `-mpclmul` compiler flags to the Abseil and TCMalloc build definitions on x86_64, enabling Abseil's hardware-accelerated CRC32C implementation.
- Without these flags, Abseil's CRC32C code paths gated on `__SSE4_2__` and `__PCLMUL__` are compiled out entirely — `TryNewCRC32AcceleratedX86ARMCombined()` compiles to `return 0` (a stub), and all CRC32C operations fall back to a slow software table-based implementation.
- With these flags, Abseil uses SSE4.2 `crc32` hardware instructions for small buffers and PCLMULQDQ carry-less multiply for fast large-buffer folding — matching or exceeding the performance of the existing crcutil library's 3-way-striped approach.
- TCMalloc needs the same flags because it builds its own copy of Abseil source via Bazel `local_repository`.
- No aarch64 changes needed: the existing `GRAVITON_COMPILER_FLAGS` (`-march=armv8.2-a+...+crypto`) already define `__ARM_FEATURE_CRC32` and `__ARM_FEATURE_CRYPTO`, activating Abseil's ARM SIMD CRC path.

## Test plan

- [ ] Verify Abseil builds successfully on x86_64 with the new flags
- [ ] Verify TCMalloc builds successfully on x86_64 with the new flags
- [ ] Confirm the compiled `libabsl.a` / `libabsl.so` contains `crc32q` and `pclmulqdq` instructions (via `objdump -d | grep -c pclmulqdq`)
- [ ] Confirm `TryNewCRC32AcceleratedX86ARMCombined()` no longer returns 0 in the compiled library
- [ ] Verify aarch64 builds are unaffected (no flag changes on that architecture)

Made with [Cursor](https://cursor.com)