### PR TITLE
Cleanup Apple Clang build code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,20 +161,6 @@ jobs:
           # macOS
           # ---------------------------------------------------------------------------------------
 
-          - name: macos-x86_64
-            runs_on: macos-14-large
-            docker_image:
-            build_thirdparty_args: --enforce_arch=x86_64
-            architecture: x86_64
-
-          - name: macos-arm64
-            # According to https://github.com/orgs/community/discussions/69211, this is the runner
-            # type that corresponds to Apple Silicon.
-            runs_on: macos-14-xlarge
-            docker_image:
-            build_thirdparty_args: --enforce_arch=arm64
-            architecture: arm64
-
           - name: macos-x86_64-clang21
             runs_on: macos-14-large
             docker_image:

--- a/python/build_definitions/bison.py
+++ b/python/build_definitions/bison.py
@@ -28,11 +28,11 @@ class BisonDependency(Dependency):
     def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
         llvm_major_version = builder.compiler_choice.get_llvm_major_version()
         flags = []
-        llvm_installer_16_or_later = (
-            builder.compiler_choice.is_llvm_installer_clang() and
+        clang_16_or_later = (
+            builder.compiler_choice.is_clang() and
             llvm_major_version is not None and llvm_major_version >= 16)
 
-        if (is_macos() or llvm_installer_16_or_later):
+        if clang_16_or_later:
             # To avoid this error in Bison 3.4.1 build:
             # lib/obstack.c:351:31: error: incompatible function pointer types initializing
             # 'void (*)(void) __attribute__((noreturn))' with an expression of type 'void (void)'

--- a/python/build_definitions/cassandra_cpp_driver.py
+++ b/python/build_definitions/cassandra_cpp_driver.py
@@ -62,7 +62,7 @@ class CassandraCppDriverDependency(Dependency):
         extra_cxx_flags: List[str] = []
         builder.add_checked_flag(extra_cxx_flags, '-Wno-error=implicit-fallthrough')
         builder.add_checked_flag(extra_cxx_flags, '-Wno-error=class-memaccess')
-        if builder.compiler_choice.is_llvm_installer_clang():
+        if builder.compiler_choice.is_clang():
             builder.add_checked_flag(extra_cxx_flags, '-Wno-error=deprecated-declarations')
         gcc_major_version = builder.compiler_choice.get_gcc_major_version()
         if gcc_major_version is not None and gcc_major_version >= 11:

--- a/python/build_definitions/libuuid.py
+++ b/python/build_definitions/libuuid.py
@@ -26,13 +26,13 @@ class LibUuidDependency(Dependency):
 
     def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
         llvm_major_version = builder.compiler_choice.get_llvm_major_version()
-        llvm_installer_15_or_later = (
-            builder.compiler_choice.is_llvm_installer_clang() and
+        clang_15_or_later = (
+            builder.compiler_choice.is_clang() and
             llvm_major_version is not None and llvm_major_version >= 15)
         gcc_major_version = builder.compiler_choice.get_gcc_major_version()
         gcc_15_or_later = (gcc_major_version is not None and gcc_major_version >= 15)
         flags = []
-        if llvm_installer_15_or_later or gcc_15_or_later:
+        if clang_15_or_later or gcc_15_or_later:
             # https://gist.githubusercontent.com/mbautin/9ae79d6c81adaa68746287458cac4d10/raw
             flags.append('-Wno-error=implicit-function-declaration')
 

--- a/python/build_definitions/llvm_libcxx.py
+++ b/python/build_definitions/llvm_libcxx.py
@@ -31,7 +31,7 @@ class LlvmLibCxxDependencyBase(LlvmPartDependencyBase):
             builder: BuilderInterface,
             ninja_build_file_path: str) -> None:
         super().postprocess_ninja_build_file(builder, ninja_build_file_path)
-        if not builder.compiler_choice.is_llvm_installer_clang():
+        if not builder.compiler_choice.is_clang():
             return
 
         if builder.build_type not in [BuildType.ASAN, BuildType.TSAN]:
@@ -46,7 +46,7 @@ class LlvmLibCxxDependencyBase(LlvmPartDependencyBase):
             num_lines_modified, os.path.abspath(ninja_build_file_path), removed_string)
 
     def get_additional_ld_flags(self, builder: BuilderInterface) -> List[str]:
-        if (builder.compiler_choice.is_llvm_installer_clang() and
+        if (builder.compiler_choice.is_clang() and
                 builder.build_type in [BuildType.ASAN, BuildType.TSAN]):
             # We need to link with these libraries in ASAN because otherwise libc++ CMake
             # configuration step fails and some C standard library functions cannot be found.

--- a/python/build_definitions/openldap.py
+++ b/python/build_definitions/openldap.py
@@ -29,19 +29,19 @@ class OpenLDAPDependency(Dependency):
 
     def get_additional_compiler_flags(self, builder: BuilderInterface) -> List[str]:
         llvm_major_version = builder.compiler_choice.get_llvm_major_version()
-        llvm_installer_15_or_later = (
-            builder.compiler_choice.is_llvm_installer_clang() and
+        clang_15_or_later = (
+            builder.compiler_choice.is_clang() and
             llvm_major_version is not None and llvm_major_version >= 15)
         gcc_major_version = builder.compiler_choice.get_gcc_major_version()
         gcc_15_or_later = (gcc_major_version is not None and gcc_major_version >= 15)
         flags = []
 
-        if is_macos() or llvm_installer_15_or_later or gcc_15_or_later:
-            # To avoid this error with Clang 15 on Linux:
+        if clang_15_or_later or gcc_15_or_later:
+            # To avoid this error with Clang 15+:
             # https://gist.githubusercontent.com/mbautin/a9ca659ec5955ecb0e3d469376659c2b/raw
             flags.append('-Wno-error=implicit-function-declaration')
 
-            # See the links for the errors with Clang 15 on Linux that make the corresponding
+            # See the links for the errors with Clang 15+ that make the corresponding
             # -Wno-error=... flags necessary.
             flags.extend([
                 # https://gist.githubusercontent.com/mbautin/354c8882998067a87ec8c832d454603f/raw

--- a/python/yugabyte_db_thirdparty/builder.py
+++ b/python/yugabyte_db_thirdparty/builder.py
@@ -324,7 +324,7 @@ class Builder(BuilderInterface):
                 get_build_def_module('libuuid').LibUuidDependency(),
             ]
 
-        if is_linux() or self.compiler_choice.is_llvm_installer_clang():
+        if is_linux() or self.compiler_choice.is_clang():
             llvm_major_version: Optional[int] = self.compiler_choice.get_llvm_major_version()
             if (self.compiler_choice.is_clang() and
                     llvm_major_version is not None and llvm_major_version >= 10):
@@ -514,13 +514,6 @@ class Builder(BuilderInterface):
         elif is_macos():
             self.shared_lib_suffix = "dylib"
 
-            if not self.compiler_choice.is_llvm_installer_clang():
-                # YugaByte builds with C++23, which on OS X requires using libc++ as the standard
-                # library implementation. Some of the dependencies do not compile against libc++ by
-                # default, so we specify it explicitly.
-                self.cxx_flags.append("-stdlib=libc++")
-                self.ld_flags += ["-lc++", "-lc++abi"]
-
             # Build for macOS Mojave or later. See https://bit.ly/37myHbk
             extend_lists(
                 [self.compiler_flags, self.ld_flags, self.assembler_flags],
@@ -547,10 +540,7 @@ class Builder(BuilderInterface):
         # issues with handling exceptions. We are force-including this flag even though there are
         # "proper" ways to specify the C++ standard for various build systems, e.g. CMake's
         # CMAKE_CXX_STANDARD.
-        if is_macos() and not self.compiler_choice.is_llvm_installer_clang():
-            self.cxx_flags.append(f'-std=c++{constants.OSX_CXX_STANDARD}')
-        else:
-            self.cxx_flags.append(f'-std=c++{constants.CXX_STANDARD}')
+        self.cxx_flags.append(f'-std=c++{constants.CXX_STANDARD}')
 
     def add_lib_dir_and_rpath(self, lib_dir: str) -> None:
         if self.args.verbose:
@@ -873,13 +863,10 @@ class Builder(BuilderInterface):
         # Explicitly pass the C++ standard via --cxxopt to ensure it is respected by all Bazel
         # C++ toolchains (including the Apple toolchain on macOS, which may not honor
         # BAZEL_CXXOPTS).
-        if is_macos() and not self.compiler_choice.is_llvm_installer_clang():
-            cxx_std_flag = f"-std=c++{constants.OSX_CXX_STANDARD}"
-        else:
-            cxx_std_flag = f"-std=c++{constants.CXX_STANDARD}"
-            # See https://github.com/bazelbuild/bazel/issues/4231. Without this, setting CC variable
-            # doesn't work on macOS builds when Xcode is installed.
-            build_command += ["--action_env", f"BAZEL_USE_CPP_ONLY_TOOLCHAIN=1"]
+        cxx_std_flag = f"-std=c++{constants.CXX_STANDARD}"
+        # See https://github.com/bazelbuild/bazel/issues/4231. Without this, setting CC variable
+        # doesn't work on macOS builds when Xcode is installed.
+        build_command += ["--action_env", f"BAZEL_USE_CPP_ONLY_TOOLCHAIN=1"]
         build_command += ["--cxxopt", cxx_std_flag]
 
         # Need to explicitly pass environment variables which we want to be available.
@@ -1044,8 +1031,8 @@ class Builder(BuilderInterface):
         """
         self.init_compiler_independent_flags(dep)
 
-        if self.compiler_choice.is_llvm_installer_clang():
-            # Special setup for LLVM installer Clang.
+        if self.compiler_choice.is_clang():
+            # Special setup for Clang.
             compiler_choice = self.compiler_choice
             llvm_major_version: Optional[int] = compiler_choice.get_llvm_major_version()
             if llvm_major_version is not None and llvm_major_version >= 10:

--- a/python/yugabyte_db_thirdparty/cmd_line_args.py
+++ b/python/yugabyte_db_thirdparty/cmd_line_args.py
@@ -19,7 +19,7 @@ import platform
 from typing import Dict, Set
 from argparse_utils import enum_action  # type: ignore
 
-from sys_detection import is_macos, local_sys_conf
+from sys_detection import local_sys_conf
 
 from build_definitions import BuildType
 

--- a/python/yugabyte_db_thirdparty/compiler_choice.py
+++ b/python/yugabyte_db_thirdparty/compiler_choice.py
@@ -174,6 +174,7 @@ class CompilerChoice:
 
     def is_clang(self) -> bool:
         assert self.compiler_family is not None
+        assert self.expected_major_compiler_version is not None
         return self.compiler_family == 'clang'
 
     def is_gcc(self) -> bool:
@@ -189,9 +190,6 @@ class CompilerChoice:
 
     def is_linux_clang(self) -> bool:
         return is_linux() and self.is_clang()
-
-    def is_llvm_installer_clang(self) -> bool:
-        return self.expected_major_compiler_version is not None and self.is_clang()
 
     def set_compiler(self, use_compiler_wrapper: Optional[bool] = None) -> None:
         if use_compiler_wrapper is not None:

--- a/python/yugabyte_db_thirdparty/compiler_flag_util.py
+++ b/python/yugabyte_db_thirdparty/compiler_flag_util.py
@@ -34,8 +34,7 @@ def get_cxx_standard_version_from_flag(flag: str) -> str:
 
 
 def is_correct_cxx_standard_version(version: Union[int, str]) -> bool:
-    return str(version) == str(constants.CXX_STANDARD) or \
-           str(version) == str(constants.OSX_CXX_STANDARD)
+    return str(version) == str(constants.CXX_STANDARD)
 
 
 def get_cxx_standard_version_set(cmd_args: List[str]) -> Set[str]:

--- a/python/yugabyte_db_thirdparty/constants.py
+++ b/python/yugabyte_db_thirdparty/constants.py
@@ -21,4 +21,3 @@ SRC_PATH_FILE_NAME = 'yb_dep_src_path.txt'
 GIT_CLONE_DEPTH = 10
 
 CXX_STANDARD = 23
-OSX_CXX_STANDARD = '2b'

--- a/python/yugabyte_db_thirdparty/dependency.py
+++ b/python/yugabyte_db_thirdparty/dependency.py
@@ -13,8 +13,6 @@
 import os
 from typing import Optional, List, Set, TYPE_CHECKING
 
-from sys_detection import is_linux, is_macos
-
 from build_definitions import ExtraDownload, BuildGroup
 from yugabyte_db_thirdparty.archive_handling import make_archive_name
 from yugabyte_db_thirdparty.git_util import parse_github_url
@@ -128,7 +126,7 @@ class Dependency:
         compiler wrapper command line.
         """
         llvm_major_version: Optional[int] = builder.compiler_choice.get_llvm_major_version()
-        if (builder.compiler_choice.is_llvm_installer_clang() and
+        if (builder.compiler_choice.is_clang() and
                 llvm_major_version is not None and
                 llvm_major_version >= 12 and
                 builder.lto_type is not None):


### PR DESCRIPTION
Remove old build code needed to support Apple Clang builds, which we no longer use:
- is_llvm_installer_clang() uses were replaced with is_clang(): this was only used to distinguish between llvm-installer Clang and Apple Clang. We now always assume llvm-installer Clang, so this is now functionally equivalent to is_clang().
- OSX_CXX_STANDARD was used for Apple Clang only, since the available versions of Apple Clang didn't understand `-std=c++23`. This has been removed.
- Apple Clang-specific build flags were removed.
- Apple Clang builds of thirdparty were removed.